### PR TITLE
Workflow

### DIFF
--- a/.github/workflows/scan-publish.yml
+++ b/.github/workflows/scan-publish.yml
@@ -1,12 +1,12 @@
 name: Scan and Publish Docker Image
 
 on:
-  [ push ]
-  #   branches: [ main ]
-  #   # Publish semver tags as releases.
-  #   tags: [ 'v*.*.*' ]
-  # pull_request:
-  #     branches: [ main ]
+  push:
+    branches: [ main ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+      branches: [ main ]
 
 
 env:
@@ -95,18 +95,15 @@ jobs:
           context: .
           platforms: linux/amd64
           push: false
-          #sbom: true
+          sbom: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
-          #|
-          #  ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}
-          #  ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest
 
-      # - name: Print cosign version
-      #   if: ${{ github.event_name != 'pull_request' }}
-      #   run: cosign version
+      - name: Print cosign version
+        if: ${{ github.event_name != 'pull_request' }}
+        run: cosign version
 
-      # - name: Sign the container image
-      #   if: ${{ github.event_name != 'pull_request' }}
-      #   run: cosign sign -y ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}@${{ steps.push-step.outputs.digest }} ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest@${{ steps.push-step.outputs.digest }}
+      - name: Sign the container image
+        if: ${{ github.event_name != 'pull_request' }}
+        run: cosign sign -y ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}@${{ steps.push-step.outputs.digest }} ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest@${{ steps.push-step.outputs.digest }}
   

--- a/.github/workflows/scan-publish.yml
+++ b/.github/workflows/scan-publish.yml
@@ -88,13 +88,12 @@ jobs:
           format: 'table'
 
       - name: Build and push
-        if: ${{ github.event_name != 'pull_request' }}
         id: push-step
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
           sbom: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/scan-publish.yml
+++ b/.github/workflows/scan-publish.yml
@@ -68,6 +68,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/scan-publish.yml
+++ b/.github/workflows/scan-publish.yml
@@ -1,12 +1,12 @@
 name: Scan and Publish Docker Image
 
 on:
-  push:
-    branches: [ main ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
-#   pull_request:
-#     branches: [ main ]
+  [ push ]
+  #   branches: [ main ]
+  #   # Publish semver tags as releases.
+  #   tags: [ 'v*.*.*' ]
+  # pull_request:
+  #     branches: [ main ]
 
 
 env:
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
+        if: ${{ github.event_name != 'pull_request' }}
         uses: sigstore/cosign-installer@v3.6.0
 
       - name: Set up QEMU
@@ -60,7 +61,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}
+          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Clean Repository Name
         id: toLowerCase
@@ -82,20 +88,25 @@ jobs:
           format: 'table'
 
       - name: Build and push
+        if: ${{ github.event_name != 'pull_request' }}
         id: push-step
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/amd64
-          push: true
-          sbom: true
+          push: false
+          #sbom: true
           labels: ${{ steps.meta.outputs.labels }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}
-            ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          #|
+          #  ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}
+          #  ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest
 
-      - name: Print cosign version
-        run: cosign version
+      # - name: Print cosign version
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   run: cosign version
 
-      - name: Sign the container image
-        run: cosign sign -y ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}@${{ steps.push-step.outputs.digest }} ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest@${{ steps.push-step.outputs.digest }}
+      # - name: Sign the container image
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   run: cosign sign -y ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.sha }}@${{ steps.push-step.outputs.digest }} ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest@${{ steps.push-step.outputs.digest }}
   

--- a/.github/workflows/scan-publish.yml
+++ b/.github/workflows/scan-publish.yml
@@ -62,11 +62,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+
 
       - name: Clean Repository Name
         id: toLowerCase

--- a/.github/workflows/scan-publish.yml
+++ b/.github/workflows/scan-publish.yml
@@ -57,18 +57,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}
-
-
       - name: Clean Repository Name
         id: toLowerCase
         run: echo "REPO_NAME=${REPO_NAME,,}" >> "${GITHUB_ENV}"
         env:
           REPO_NAME: ${{ github.repository }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}
 
       - name: Build Image
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
+ARG BUILDKIT_SBOM_SCAN_STAGE=base,final
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS base
-ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 WORKDIR /app
 


### PR DESCRIPTION
Updated scan-publish.yml to
- build, push, and sign image only from main when a version tag is applied.
- better utilize docker/metadata-action for tags generation
- not push the image when the event is a PR.